### PR TITLE
Correct list item formatting for definitions in 252.204-7018

### DIFF
--- a/dita/252.204-7018.dita
+++ b/dita/252.204-7018.dita
@@ -18,7 +18,7 @@ following clause:</p>
          <p outputclass="Ctr_SmCaps" class="- topic/p ">PROHIBITION ON THE ACQUISITION OF
 COVERED DEFENSE TELECOMMUNICATIONS EQUIPMENT OR SERVICES (JAN 2023)
          </p>
-         <p class="- topic/p ">Definitions. As used in this clause—</p>
+         <p class="- topic/p ">(a) <i class="+ topic/ph hi-d/i ">Definitions</i>. As used in this clause—</p>
          <p class="- topic/p ">“Covered defense telecommunications equipment or services” means—</p>
          <p outputclass="List2" class="- topic/p ">(1) Telecommunications equipment produced
 by Huawei Technologies Company or ZTE Corporation, or any subsidiary or


### PR DESCRIPTION
PR formats the "Definitions" list item in 252.204-7018 -- adds missing `(a)` and wraps title in `<i>`.   See, for reference, https://www.ecfr.gov/current/title-48/chapter-2/subchapter-H/part-252/subpart-252.2/section-252.204-7018

cc @GregPangborn